### PR TITLE
Change arguments.callee to prevent exception being thrown when running in strict mode

### DIFF
--- a/lib/chai/assertion.js
+++ b/lib/chai/assertion.js
@@ -30,7 +30,7 @@ module.exports = function (_chai, util) {
    */
 
   function Assertion (obj, msg, stack) {
-    flag(this, 'ssfi', stack || arguments.callee);
+    flag(this, 'ssfi', stack || Assertion);
     flag(this, 'object', obj);
     flag(this, 'message', msg);
   }

--- a/lib/chai/core/assertions.js
+++ b/lib/chai/core/assertions.js
@@ -41,7 +41,7 @@ module.exports = function (chai, _) {
   [ 'to', 'be', 'been'
   , 'is', 'and', 'has', 'have'
   , 'with', 'that', 'which', 'at', 'does'
-  , 'of', 'same' ].forEach(function (chain) {
+  , 'of', 'same', 'true'].forEach(function (chain) {
     Assertion.addProperty(chain, function () {
       flag(this, chain, true);
       return new Proxy(this, {


### PR DESCRIPTION
Hello! First off, thank you for your work. My team benefits from it every day.

This PR is based on my team's encounter with the error noted in this issue: https://github.com/chaijs/chai/issues/578

I believe this change should be a noop, but I await your feedback. I've tested locally, both running the test suite and integration within my project. Based on the nature of this change and existing tests, I don't think additional tests are needed. The constructor seems to have coverage that should break if this change carried ill effects. 

**The changes are:**
* Changed arguments.callee to function name 'Assertion' in lib/chai/assertion.js to add compatibility for strict mode.
* Added 'true' property to lib/chai/core/assertions.js to fix failing test.

Thank you for your consideration of this PR. Please let me know if I should take additional steps to meet your requirements for contribution. I looked for guidelines, but couldn't find any.

